### PR TITLE
Mass memory erase fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python"
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Usage
 
     -s          Swap RTS and DTR: use RTS for reset and DTR for boot0
     -R          Make reset active high
-    -B          Make boot0 active high
+    -B          Make boot0 active low
     -u          Readout unprotect
     -n          No progress: don't show progress bar
     -P parity   Parity: "even" for STM32 (default), "none" for BlueNRG

--- a/stm32loader/.gitignore
+++ b/stm32loader/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/stm32loader/bootloader.py
+++ b/stm32loader/bootloader.py
@@ -45,7 +45,7 @@ CHIP_IDS = {
     # flash size to be looked up
     0x416: "STM32L1xxx6(8/B) Medium-density ultralow power line",
     0x411: "STM32F2xxx",
-    0x433: "STM32F4xxDE",
+    0x433: "STM32F4xxD/E",
     # RM0090 in ( 38.6.1 MCU device ID code )
     0x413: "STM32F405xx/07xx and STM32F415xx/17xx",
     0x419: "STM32F42xxx and STM32F43xxx",
@@ -335,6 +335,16 @@ class Stm32Bootloader:
         flash_size_bytes = self.read_memory(flash_size_address, 2)
         flash_size = flash_size_bytes[0] + (flash_size_bytes[1]<<8)
         return flash_size
+
+    def get_flash_size_and_uid_f4(self):
+        """ Return device_uid and flash_size for F4 family."""
+        data_start_addr = 0x1FFF7A00
+        flash_size_lsb_addr = 0x22
+        uid_lsb_addr = 0x10
+        data = self.read_memory(data_start_addr, self.DATA_TRANSFER_SIZE)
+        device_uid = data[uid_lsb_addr:uid_lsb_addr+12] 
+        flash_size = data[flash_size_lsb_addr] + data[flash_size_lsb_addr+1]<<8
+        return device_uid, flash_size
 
     def get_uid(self, device_id):
         """

--- a/stm32loader/bootloader.py
+++ b/stm32loader/bootloader.py
@@ -45,8 +45,10 @@ CHIP_IDS = {
     # flash size to be looked up
     0x416: "STM32L1xxx6(8/B) Medium-density ultralow power line",
     0x411: "STM32F2xxx",
-    0x413: "STM32F40xxx/41xxx",
-    0x419: "STM3242xxx/43xxx",
+    0x433: "STM32F4xxDE",
+    # RM0090 in ( 38.6.1 MCU device ID code )
+    0x413: "STM32F405xx/07xx and STM32F415xx/17xx",
+    0x419: "STM32F42xxx and STM32F43xxx",
     0x449: "STM32F74xxx/75xxx",
     0x451: "STM32F76xxx/77xxx",
     # see ST AN4872
@@ -193,7 +195,7 @@ class Stm32Bootloader:
         "F1": 0x1FFFF7E8,
         # ST RM0090 section 39.1 Unique device ID register
         # F405/415, F407/417, F427/437, F429/439
-        "F4": 0x1FFFF7A10,
+        "F4": 0x1FFF7A10,
         # ST RM0385 section 41.2 Unique device ID register
         "F7": 0x1FF0F420,
     }
@@ -308,10 +310,14 @@ class Stm32Bootloader:
         Read protection status readout is not yet implemented.
         """
         self.command(self.Command.GET_VERSION, "Get version")
-        version = bytearray(self.connection.read())[0]
-        self.connection.read(2)
+        data = bytearray(self.connection.read(3))
+        version = data[0]
+        option_byte1 = data[1]
+        option_byte2 = data[2]
         self._wait_for_ack("0x01 end")
         self.debug(10, "    Bootloader version: " + hex(version))
+        self.debug(10, "    Option byte 1: " + hex(option_byte1))
+        self.debug(10, "    Option byte 2: " + hex(option_byte2))
         return version
 
     def get_id(self):
@@ -327,7 +333,7 @@ class Stm32Bootloader:
         """Return the MCU's flash size in bytes."""
         flash_size_address = self.FLASH_SIZE_ADDRESS[device_family]
         flash_size_bytes = self.read_memory(flash_size_address, 2)
-        flash_size = flash_size_bytes[0] + flash_size_bytes[1] * self.DATA_TRANSFER_SIZE
+        flash_size = flash_size_bytes[0] + (flash_size_bytes[1]<<8)
         return flash_size
 
     def get_uid(self, device_id):
@@ -349,7 +355,7 @@ class Stm32Bootloader:
             return self.UID_NOT_SUPPORTED
         if uid_address == self.UID_ADDRESS_UNKNOWN:
             return self.UID_ADDRESS_UNKNOWN
-
+            
         uid = self.read_memory(uid_address, 12)
         return uid
 

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -252,15 +252,26 @@ class Stm32Loader:
         if not family:
             self.debug(0, "Supply -f [family] to see flash size and device UID, e.g: -f F1")
         else:
-            try:
-                device_uid = self.stm32.get_uid(family)
-                flash_size = self.stm32.get_flash_size(family)
-            except bootloader.CommandError as e:
-                self.debug(0,"Something was wrong with reading chip family data: " + e.message)
+            # special fix for F4 devices
+            if family == "F4":
+                try:
+                    device_uid, flash_size = self.stm32.get_flash_size_and_uid_f4()
+                except bootloader.CommandError as e:
+                    self.debug(0,"Something was wrong with reading chip family data: " + e.message)
+                else:
+                    device_uid_string = self.stm32.format_uid(device_uid)
+                    self.debug(0, "Device UID: %s" % device_uid_string)
+                    self.debug(0, "Flash size: %d KiB" % flash_size)
             else:
-                device_uid_string = self.stm32.format_uid(device_uid)
-                self.debug(0, "Device UID: %s" % device_uid_string)
-                self.debug(0, "Flash size: %d KiB" % flash_size)
+                try:
+                    flash_size = self.stm32.get_flash_size(family)
+                    device_uid = self.stm32.get_uid(family)
+                except bootloader.CommandError as e:
+                    self.debug(0,"Something was wrong with reading chip family data: " + e.message)
+                else:
+                    device_uid_string = self.stm32.format_uid(device_uid)
+                    self.debug(0, "Device UID: %s" % device_uid_string)
+                    self.debug(0, "Flash size: %d KiB" % flash_size)
 
     def _parse_option_flags(self, options):
         # pylint: disable=eval-used

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -243,21 +243,24 @@ class Stm32Loader:
     def read_device_details(self):
         """Show MCU details (bootloader version, chip ID, UID, flash size)."""
         boot_version = self.stm32.get()
-        self.debug(0, "Bootloader version %X" % boot_version)
+        self.debug(0, "Bootloader version: 0x%X" % boot_version)
         device_id = self.stm32.get_id()
         self.debug(
-            0, "Chip id: 0x%x (%s)" % (device_id, bootloader.CHIP_IDS.get(device_id, "Unknown"))
+            0, "Chip id: 0x%X (%s)" % (device_id, bootloader.CHIP_IDS.get(device_id, "Unknown"))
         )
         family = self.configuration["family"]
         if not family:
             self.debug(0, "Supply -f [family] to see flash size and device UID, e.g: -f F1")
         else:
-            device_uid = self.stm32.get_uid(family)
-            device_uid_string = self.stm32.format_uid(device_uid)
-            self.debug(0, "Device UID: %s" % device_uid_string)
-
-            flash_size = self.stm32.get_flash_size(family)
-            self.debug(0, "Flash size: %d KiB" % flash_size)
+            try:
+                device_uid = self.stm32.get_uid(family)
+                flash_size = self.stm32.get_flash_size(family)
+            except bootloader.CommandError as e:
+                self.debug(0,"Something was wrong with reading chip family data: " + e.message)
+            else:
+                device_uid_string = self.stm32.format_uid(device_uid)
+                self.debug(0, "Device UID: %s" % device_uid_string)
+                self.debug(0, "Flash size: %d KiB" % flash_size)
 
     def _parse_option_flags(self, options):
         # pylint: disable=eval-used

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -48,7 +48,7 @@ class Stm32Loader:
         "-s": "swap_rts_dtr",
         "-n": "hide_progress_bar",
         "-R": "reset_active_high",
-        "-B": "boot0_active_high",
+        "-B": "boot0_active_low",
     }
 
     INTEGER_OPTIONS = {"-b": "baud", "-a": "address", "-g": "go_address", "-l": "length"}
@@ -70,7 +70,7 @@ class Stm32Loader:
             "go_address": -1,
             "swap_rts_dtr": False,
             "reset_active_high": False,
-            "boot0_active_high": False,
+            "boot0_active_low": False,
             "hide_progress_bar": False,
             "data_file": None,
         }
@@ -134,7 +134,7 @@ class Stm32Loader:
 
         serial_connection.swap_rts_dtr = self.configuration["swap_rts_dtr"]
         serial_connection.reset_active_high = self.configuration["reset_active_high"]
-        serial_connection.boot0_active_high = self.configuration["boot0_active_high"]
+        serial_connection.boot0_active_low = self.configuration["boot0_active_low"]
 
         show_progress = self._get_progress_bar(self.configuration["hide_progress_bar"])
 
@@ -228,7 +228,7 @@ class Stm32Loader:
 
     -s          Swap RTS and DTR: use RTS for reset and DTR for boot0
     -R          Make reset active high
-    -B          Make boot0 active high
+    -B          Make boot0 active low
     -u          Readout unprotect
     -n          No progress: don't show progress bar
     -P parity   Parity: "even" for STM32 (default), "none" for BlueNRG

--- a/stm32loader/uart.py
+++ b/stm32loader/uart.py
@@ -26,10 +26,9 @@ Offer support for toggling RESET and BOOT0.
 # not naming this file itself 'serial', becase that name-clashes in Python 2
 import serial
 
-
 # fixes the problem with setters methods
 # https://stackoverflow.com/questions/598077/why-does-foo-setter-in-python-not-work-for-me
-class SerialConnection(object)
+class SerialConnection(object):
     """Wrap a serial.Serial connection and toggle reset and boot0."""
 
     # pylint: disable=too-many-instance-attributes

--- a/stm32loader/uart.py
+++ b/stm32loader/uart.py
@@ -27,7 +27,9 @@ Offer support for toggling RESET and BOOT0.
 import serial
 
 
-class SerialConnection:
+# fixes the problem with setters methods
+# https://stackoverflow.com/questions/598077/why-does-foo-setter-in-python-not-work-for-me
+class SerialConnection(object)
     """Wrap a serial.Serial connection and toggle reset and boot0."""
 
     # pylint: disable=too-many-instance-attributes
@@ -44,15 +46,12 @@ class SerialConnection:
 
         self.swap_rts_dtr = False
         self.reset_active_high = False
-        self.boot0_active_high = False
+        self.boot0_active_low = False
 
         # call connect() to establish connection
         self.serial_connection = None
 
-        self._timeout = None
-
-        # assigned using setter methods
-        self.timeout = 5
+        self._timeout = 5
 
     @property
     def timeout(self):
@@ -109,8 +108,8 @@ class SerialConnection:
         """Enable or disable the boot0 IO line."""
         level = int(enable)
 
-        # by default, this is active low
-        if not self.boot0_active_high:
+        # by default, this is active high
+        if not self.boot0_active_low:
             level = 1 - level
 
         if self.swap_rts_dtr:

--- a/stm32loader/uart.py
+++ b/stm32loader/uart.py
@@ -49,6 +49,22 @@ class SerialConnection:
         # call connect() to establish connection
         self.serial_connection = None
 
+        self._timeout = None
+
+        # assigned using setter methods
+        self.timeout = 5
+
+    @property
+    def timeout(self):
+        """Get timeout."""
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, timeout):
+        """Set timeout."""
+        self._timeout = timeout
+        self.serial_connection.timeout = timeout
+
     def connect(self):
         """Connect to the RS-232 serial port."""
         self.serial_connection = serial.Serial(
@@ -63,7 +79,7 @@ class SerialConnection:
             # don't enable RTS/CTS flow control
             rtscts=0,
             # set a timeout value, None for waiting forever
-            timeout=5,
+            timeout=self._timeout,
         )
 
     def write(self, *args, **kwargs):


### PR DESCRIPTION
I fixed bug that prevented mass storage erase and added better handling of the `CommandError` exception when reading chip family data (`-f` options). I don't know why, but it always throws exception with `NACK 0x11 length failed` when reading uid and flash size. There are also other small changes/fixes.