### PR TITLE
Add STM32G0x1

### DIFF
--- a/stm32loader/bootloader.py
+++ b/stm32loader/bootloader.py
@@ -37,6 +37,7 @@ CHIP_IDS = {
     # 64 to 128 KiB
     0x410: "STM32F10x Medium-density",
     0x420: "STM32F10x Medium-density value line",
+    0x460: "STM32G0x1",
     # 256 to 512 KiB (5128 Kbyte is probably a typo?)
     0x414: "STM32F10x High-density",
     0x428: "STM32F10x High-density value line",
@@ -198,6 +199,8 @@ class Stm32Bootloader:
         "F4": 0x1FFF7A10,
         # ST RM0385 section 41.2 Unique device ID register
         "F7": 0x1FF0F420,
+        # ST RM0444 section 38.1 Unique device ID register
+        "G0": 0x1FFF7590,
     }
 
     UID_SWAP = [[1, 0], [3, 2], [7, 6, 5, 4], [11, 10, 9, 8]]
@@ -219,6 +222,8 @@ class Stm32Bootloader:
         "F4": 0x1FFF7A22,
         # ST RM0385 section 41.2 Flash size
         "F7": 0x1FF0F442,
+        # ST RM0444 section 38.2 Flash memory size data register
+        "G0": 0x1FFF75E0,
     }
 
     DATA_TRANSFER_SIZE = 256  # bytes


### PR DESCRIPTION
This PR adds the STM32G0x1 to the identification list.

Here is the output.
```
sudo stm32loader -p /dev/serial0 -f G0 -V
Open port /dev/serial0, baud 115200
*** Command: Get
    Bootloader version: 0x31
    Available commands: 0x0, 0x1, 0x2, 0x11, 0x21, 0x31, 0x44, 0x63, 0x73, 0x82, 0x92
Bootloader version: 0x31
*** Command: Get ID
Chip id: 0x460 (STM32G0x1)
*** Command: Read memory
*** Command: Read memory
Device UID: 0085-004C-31365011-20383048
Flash size: 128 KiB
```
