### PR TITLE
More robust bootloader activation

### DIFF
--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -143,6 +143,7 @@ class Stm32Loader:
         )
 
         try:
+            print("Sending UART select to bootloader, attempting twice")
             self.stm32.reset_from_system_memory()
         except bootloader.CommandError:
             print(


### PR DESCRIPTION
This PR allows multiple reprogramming sessions/invocations while still in bootloader mode (without needing to pull nRST to reset STM32 chip).

In short, it tries to send `0x7F` twice at the beginning.

There are 3 possible states what can happen after sending `0x7F` when in bootloader mode:

  1. right after reset you'll get `ACK`
  1. you get nothing (timeout)
  1. you get `NACK`

States 2 and 3 happen if you want send multiple commands to the bootloader without resetting chip, or use multiple invocations of stm32loader. So in case of timeout, resend `0x7F`, you should get `NACK` back (though my code also allows `ACK` just in case).

The official ST tools use exactly this, even though it appears to be undocumented behavior (or perhaps an artifact caused by fact that each command has 2 bytes which need to xor to 0xFF).

I tested stm32loader on STM32F429, STM32F03, but seen the behavior on other STM32 variants.