### PR TITLE
Fix issue in Bootloader constructor and add support for STM32WL

### DIFF
--- a/stm32loader/bootloader.py
+++ b/stm32loader/bootloader.py
@@ -68,6 +68,7 @@ CHIP_IDS = {
     0x445: "STM32F070x6",
     0x448: "STM32F070xB",
     0x442: "STM32F030xC",
+    0x497: "STM32WLE5xx/WL55xx",
     # Cortex-M0 MCU with hardware TCP/IP and MAC
     # (SweetPeas custom bootloader)
     0x801: "Wiznet W7500",
@@ -225,6 +226,9 @@ class Stm32Bootloader:
         "L0": 0x1FF80050,
         # ST RM0444 section 38.1 Unique device ID register
         "G0": 0x1FFF7590,
+        # ST RM0453 section 39.1.1 Unique device ID register
+        "WL": 0x1FFF7590,
+        
     }
 
     UID_SWAP = [[1, 0], [3, 2], [7, 6, 5, 4], [11, 10, 9, 8]]
@@ -260,6 +264,8 @@ class Stm32Bootloader:
         "L0": 0x1FF8007C,
         # ST RM0444 section 38.2 Flash memory size data register
         "G0": 0x1FFF75E0,
+        # ST RM0453 section 39.1.2 Flash size data register
+        "WL": 0x1FFF75E0
     }
 
     DATA_TRANSFER_SIZE = {
@@ -286,6 +292,7 @@ class Stm32Bootloader:
         "L0": 128,  # bytes
         # ST RM0444 section 38.1 Unique device ID register
         "G0": 256,  # bytes
+        "WL": 256,  # bytes
     }
 
     FLASH_PAGE_SIZE = {
@@ -313,6 +320,7 @@ class Stm32Bootloader:
         "L0": 128,  # bytes
         # ST RM0444 section 38.2 Flash memory size data register
         "G0": 1024,  # bytes
+        "WL": 1024,  # bytes
     }
 
     SYNCHRONIZE_ATTEMPTS = 2

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -81,6 +81,11 @@ class Stm32Loader:
 
     def parse_arguments(self, arguments):
         """Parse the list of command-line arguments."""
+
+        def auto_int(x):
+            """Convert to int with automatic base detection."""
+            return int(x, 0)
+
         parser = argparse.ArgumentParser(
             prog="stm32loader",
             description="Flash firmware to STM32 microcontrollers.",
@@ -129,7 +134,7 @@ class Stm32Loader:
         )
 
         length_arg = parser.add_argument(
-            "-l", "--length", action="store", type=int, help="Length of read."
+            "-l", "--length", action="store", type=auto_int, help="Length of read."
         )
 
         default_port = os.environ.get("STM32LOADER_SERIAL_PORT")
@@ -149,14 +154,14 @@ class Stm32Loader:
         )
 
         address_arg = parser.add_argument(
-            "-a", "--address", action="store", type=int, default=0x08000000, help="Target address."
+            "-a", "--address", action="store", type=auto_int, default=0x08000000, help="Target address."
         )
 
         parser.add_argument(
             "-g",
             "--go-address",
             action="store",
-            type=int,
+            type=auto_int,
             metavar="ADDRESS",
             help="Start executing from address (0x08000000, usually).",
         )

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -290,7 +290,7 @@ class Stm32Loader:
         show_progress = self._get_progress_bar(self.configuration.no_progress)
 
         self.stm32 = bootloader.Stm32Bootloader(
-            serial_connection, verbosity=self.configuration.verbosity, show_progress=show_progress
+            serial_connection, verbosity=self.configuration.verbosity, show_progress=show_progress, device_family=self.configuration.family
         )
 
         try:


### PR DESCRIPTION
- closes #62 
- closes #64 
- adds configuration parameters for STM32WL family of devices