### PR TITLE
STM32L0 devices erase fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 __pycache__/
 *.py[cod]
 .nox/
+loader-env

--- a/stm32loader/bootloader.py
+++ b/stm32loader/bootloader.py
@@ -71,6 +71,7 @@ CHIP_IDS = {
     # Cortex-M0 MCU with hardware TCP/IP and MAC
     # (SweetPeas custom bootloader)
     0x801: "Wiznet W7500",
+    0x457: "STM32L01xxx/02xxx"
 }
 
 
@@ -623,6 +624,10 @@ class Stm32Bootloader:
         :param iterable pages: Iterable of integer page addresses, zero-based.
           Set to None to trigger global mass erase.
         """
+        if not pages and self.device_family in ('L0', ):
+            flash_size, _uid = self.get_flash_size_and_uid()
+            pages = list(range(0, (flash_size*1024) // self.flash_page_size))
+
         self.command(self.Command.EXTENDED_ERASE, "Extended erase memory")
         if pages:
             # page erase, see ST AN3155

--- a/stm32loader/bootloader.py
+++ b/stm32loader/bootloader.py
@@ -363,6 +363,16 @@ class Stm32Bootloader:
         if self.verbosity >= level:
             print(message, file=sys.stderr)
 
+    def push_extra_command(self, command:bytes):
+        print(f"Sending boot command: {command}")
+        self.connection.write(command)
+
+        tm = time.time()
+        while True:
+            _ = self.connection.read().hex()
+            if time.time() > (tm + 3):
+                break
+
     def reset_from_system_memory(self):
         """Reset the MCU with boot0 enabled to enter the bootloader."""
         self._enable_boot0(True)

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -81,6 +81,11 @@ class Stm32Loader:
 
     def parse_arguments(self, arguments):
         """Parse the list of command-line arguments."""
+
+        def auto_int(x):
+            """Convert to int with automatic base detection."""
+            return int(x, 0)
+
         parser = argparse.ArgumentParser(
             prog="stm32loader",
             description="Flash firmware to STM32 microcontrollers.",
@@ -129,7 +134,7 @@ class Stm32Loader:
         )
 
         length_arg = parser.add_argument(
-            "-l", "--length", action="store", type=int, help="Length of read."
+            "-l", "--length", action="store", type=auto_int, help="Length of read."
         )
 
         default_port = os.environ.get("STM32LOADER_SERIAL_PORT")
@@ -149,14 +154,14 @@ class Stm32Loader:
         )
 
         address_arg = parser.add_argument(
-            "-a", "--address", action="store", type=int, default=0x08000000, help="Target address."
+            "-a", "--address", action="store", type=auto_int, default=0x08000000, help="Target address."
         )
 
         parser.add_argument(
             "-g",
             "--go-address",
             action="store",
-            type=int,
+            type=auto_int,
             metavar="ADDRESS",
             help="Start executing from address (0x08000000, usually).",
         )
@@ -290,7 +295,7 @@ class Stm32Loader:
         show_progress = self._get_progress_bar(self.configuration.no_progress)
 
         self.stm32 = bootloader.Stm32Bootloader(
-            serial_connection, verbosity=self.configuration.verbosity, show_progress=show_progress
+            serial_connection, verbosity=self.configuration.verbosity, show_progress=show_progress, device_family=self.configuration.family
         )
 
         try:

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -86,6 +86,11 @@ class Stm32Loader:
             """Convert to int with automatic base detection."""
             return int(x, 0)
 
+        def raw_data(x):
+            """Convert to bytes."""
+            x = x.encode('utf-8').decode('unicode_escape')
+            return bytes(x,'utf8')
+
         parser = argparse.ArgumentParser(
             prog="stm32loader",
             description="Flash firmware to STM32 microcontrollers.",
@@ -223,6 +228,14 @@ class Stm32Loader:
             help='Parity: "even" for STM32, "none" for BlueNRG.',
         )
 
+        parser.add_argument(
+            "-C",
+            "--command",
+            action="store",
+            type=raw_data,
+            help='Pass extra command to send to STM32 application to put it into boot mode.',
+        )
+
         parser.add_argument("--version", action="version", version=__version__)
 
         # Hack: We want certain arguments to be required when one
@@ -297,6 +310,9 @@ class Stm32Loader:
         self.stm32 = bootloader.Stm32Bootloader(
             serial_connection, verbosity=self.configuration.verbosity, show_progress=show_progress, device_family=self.configuration.family
         )
+
+        if self.configuration.command:
+            self.stm32.push_extra_command(self.configuration.command)
 
         try:
             print("Activating bootloader (select UART)")


### PR DESCRIPTION
As it turns out, L0 devices don't support mass erase. Erase can be performed in two ways, enabling and disabling read protection, or page by page.