### PR TITLE
BlueNRG-LP/LPS support

### DIFF
--- a/stm32loader/bootloader.py
+++ b/stm32loader/bootloader.py
@@ -27,7 +27,7 @@ import struct
 import time
 from functools import reduce
 
-from stm32loader.devices import DEVICES, DeviceFlag
+from stm32loader.devices import DEVICES, DeviceFamily, DeviceFlag
 
 
 CHIP_IDS = {
@@ -72,8 +72,6 @@ CHIP_IDS = {
     # and byte 2 (mask set).
     # Requires parity None.
     0x000003: "BlueNRG-1 160kB",
-    0x00000F: "BlueNRG-1 256kB",
-    0x000023: "BlueNRG-2 160kB",
     0x00002F: "BlueNRG-2 256kB",
     # STM32F0 RM0091 Table 136. DEV_ID and REV_ID field values
     0x440: "STM32F030x8",
@@ -553,6 +551,10 @@ class Stm32Bootloader:
 
     def detect_device(self):
         product_id = self.get_id()
+
+        # BlueNRG devices have the silicon cut version in the upper bytes of the PID
+        if self.device_family == DeviceFamily.NRG.value:
+            product_id &= 0xFF
 
         # Look up device details based on ID *without* bootloader ID.
         self.device = DEVICES.get((product_id, None))

--- a/stm32loader/main.py
+++ b/stm32loader/main.py
@@ -24,6 +24,7 @@
 import sys
 from types import SimpleNamespace
 from pathlib import Path
+import serial
 
 try:
     from progress.bar import ChargingBar as progress_bar
@@ -33,7 +34,7 @@ except ImportError:
 from stm32loader import args
 from stm32loader import hexfile
 from stm32loader import bootloader
-from stm32loader.devices import DeviceFlag
+from stm32loader.devices import DEVICE_FAMILIES, DeviceFlag, DeviceFamily
 from stm32loader.uart import SerialConnection
 
 
@@ -41,7 +42,7 @@ class Stm32Loader:
     """Main application: parse arguments and handle commands."""
 
     # serial link bit parity, compatible to pyserial serial.PARTIY_EVEN
-    PARITY = {"even": "E", "none": "N"}
+    PARITY = {"even": serial.PARITY_EVEN, "none": serial.PARITY_NONE}
 
     def __init__(self):
         """Construct Stm32Loader object with default settings."""
@@ -59,6 +60,12 @@ class Stm32Loader:
 
         # parse successful, process options further
         self.configuration.parity = Stm32Loader.PARITY[self.configuration.parity.lower()]
+
+        if self.configuration.family:
+            family = DeviceFamily[self.configuration.family]
+            family_flags = DEVICE_FAMILIES[family].family_default_flags
+            if family_flags & DeviceFlag.FORCE_PARITY_NONE:
+                self.configuration.parity = serial.PARITY_NONE
 
     def connect(self):
         """Connect to the bootloader UART over an RS-232 serial port."""
@@ -140,12 +147,14 @@ class Stm32Loader:
             try:
                 if self.configuration.length is None:
                     # Erase full device.
+                    self.debug(0, "Performing full erase...")
                     self.stm32.erase_memory(pages=None)
                 else:
                     # Erase from address to address + length.
                     start_address = self.configuration.address
                     end_address = self.configuration.address + self.configuration.length
                     pages = self.stm32.pages_from_range(start_address, end_address)
+                    self.debug(0, f"Performing partial erase (0x{start_address:X} - 0x{end_address:X}, {len(pages)} pages)... ")
                     self.stm32.erase_memory(pages)
 
             except bootloader.CommandError:
@@ -184,29 +193,10 @@ class Stm32Loader:
         boot_version = self.stm32.get()
         self.debug(0, "Bootloader version: 0x%X" % boot_version)
         self.stm32.detect_device()
-        self.debug(5, 'Bootloader ID: 0x%02X' % self.stm32.device.bootloader_id)
+        if self.stm32.device.bootloader_id is not None:
+            self.debug(5, f"Bootloader ID: 0x{self.stm32.device.bootloader_id:02X}")
         self.debug(0, f"Chip ID: 0x{self.stm32.device.product_id:03X}")
         self.debug(0, f"Chip model: {self.stm32.device.device_name}")
-
-    def read_device_id(self):
-        """Show product ID and bootloader version."""
-        boot_version = self.stm32.get()
-        self.debug(0, "Bootloader version: 0x%X" % boot_version)
-        device_id = self.stm32.get_id()
-
-        if self.configuration.family == "NRG":
-            # ST AN4872.
-            # Three bytes encode metal fix, mask set,
-            # BlueNRG-series + flash size.
-            metal_fix = (device_id & 0xFF0000) >> 16
-            mask_set = (device_id & 0x00FF00) >> 8
-            device_id = device_id & 0x0000FF
-            self.debug(0, "Metal fix: 0x%X" % metal_fix)
-            self.debug(0, "Mask set: 0x%X" % mask_set)
-
-        self.debug(
-            0, "Chip id: 0x%X (%s)" % (device_id, bootloader.CHIP_IDS.get(device_id, "Unknown"))
-        )
 
     def read_device_uid(self):
         """Show chip UID."""
@@ -215,12 +205,13 @@ class Stm32Loader:
         except bootloader.CommandError as e:
             self.debug(
                 0,
-                "Something was wrong with reading chip family data: " + str(e),
+                "Something was wrong with reading chip UID: " + str(e),
             )
             return
 
-        device_uid_string = self.stm32.format_uid(device_uid)
-        self.debug(0, "Device UID: %s" % device_uid_string)
+        if device_uid != bootloader.Stm32Bootloader.UID_NOT_SUPPORTED:
+            device_uid_string = self.stm32.format_uid(device_uid)
+            self.debug(0, "Device UID: %s" % device_uid_string)
 
     def read_flash_size(self):
         """Show chip flash size."""
@@ -229,11 +220,12 @@ class Stm32Loader:
         except bootloader.CommandError as e:
             self.debug(
                 0,
-                "Something was wrong with reading chip family data: " + str(e),
+                "Something was wrong with reading chip flash size: " + str(e),
             )
             return
 
-        self.debug(0, "Flash size: %d KiB" % flash_size)
+        if flash_size != bootloader.Stm32Bootloader.FLASH_SIZE_UNKNOWN:
+            self.debug(0, f"Flash size: {flash_size} kiB")
 
     @staticmethod
     def _get_progress_bar(no_progress=False):
@@ -254,8 +246,9 @@ def main(*arguments, **kwargs):
         loader.parse_arguments(arguments)
         loader.connect()
         try:
-            loader.read_device_id()
+            loader.detect_device()
             loader.read_device_uid()
+            loader.read_flash_size()
             loader.perform_commands()
         finally:
             loader.reset()


### PR DESCRIPTION
Adds support for BlueNRG-LP/LPS. There is no BlueNRG-1 with 256kB and no BlueNRG-2 with 160kB so I removed those, and put them all into one family (NRG).

In the future, the `--family` flag probably won't be needed much, but for BlueNRG it is required to mask the product ID and automatically switch to parity none.

Tested on STM32F030R8T6, BLUENRG-232 and BlueNRG-LP (BLUENRG-355MC)

fixes #72