### PR TITLE
Fix build with python 3.12

### DIFF
--- a/tests/unit/test_bootloader.py
+++ b/tests/unit/test_bootloader.py
@@ -213,7 +213,7 @@ def test_get_uid_for_known_family_reads_at_correct_address(connection, family):
     bootloader.read_memory = MagicMock()
     bootloader.get_uid()
     uid_address = bootloader.UID_ADDRESS[family]
-    assert bootloader.read_memory.called_once_with(uid_address)
+    bootloader.read_memory.assert_called_once_with(uid_address, 12)
 
 
 def test_get_uid_for_family_without_uid_returns_uid_not_supported(connection):


### PR DESCRIPTION
Fixes incorrect use of assert with mock object that became error on python 3.12:
https://github.com/python/cpython/issues/100690

Second arg (12) seems to come from inside `get_uid`, which I assume is the one that was tested with this mock:
https://github.com/florisla/stm32loader/blob/c56da3ddf552df033f5445963b0a0fce0259125f/stm32loader/bootloader.py#L530
