### PR TITLE
feat: support gd32vw55x

### DIFF
--- a/src/stm32loader/bootloader.py
+++ b/src/stm32loader/bootloader.py
@@ -90,6 +90,16 @@ CHIP_IDS = {
     # Cortex-M0 MCU with hardware TCP/IP and MAC
     # (SweetPeas custom bootloader)
     0x801: "Wiznet W7500",
+    # GigaDevice GD32VW55x series
+    # Uses 0x06 command to get part number (pid is 4-byte ASCII in little-endian)
+    0x50494B36: "GD32VW553KIQ6",
+    0x504D4B36: "GD32VW553KMQ6",
+    0x50494836: "GD32VW553HIQ6",
+    0x504D4836: "GD32VW553HMQ6",
+    0x50494B37: "GD32VW553KIQ7",
+    0x504D4B37: "GD32VW553KMQ7",
+    0x50494837: "GD32VW553HIQ7",
+    0x504D4837: "GD32VW553HMQ7",
 }
 
 
@@ -215,6 +225,9 @@ class Stm32Bootloader:  # pylint: disable=too-many-instance-attributes
         WRITE_PROTECT = 0x63
         WRITE_UNPROTECT = 0x73
 
+        # GD-specific command to get part number (GD32VW553 series)
+        GET_GD_ID = 0x06
+
         # not really listed under commands, but still...
         # 'wake the bootloader' == 'activate USART' == 'synchronize'
         SYNCHRONIZE = 0x7F
@@ -324,6 +337,10 @@ class Stm32Bootloader:  # pylint: disable=too-many-instance-attributes
         # ST RM0433 section 4.2 FLASH main features
         "H7": 256,
         "G4": 256,
+        # GigaDevice GD32VW553 series.
+        # In GD32 ISP Tool they send 240 bytes per transfer.
+        # In AN027 they suggest 252 bytes per transfer.
+        "GD32VW55x": 240,
     }
 
     FLASH_PAGE_SIZE = {
@@ -359,6 +376,8 @@ class Stm32Bootloader:  # pylint: disable=too-many-instance-attributes
         "G4": 2048,  # this is valid only for dual bank mode
         # ST RM0433 section 4.2 FLASH main features
         "H7": 128 * 1024,
+        # GD32VW55x series
+        "GD32VW55x": 4096,
     }
 
     device: DeviceInfo | None
@@ -529,6 +548,24 @@ class Stm32Bootloader:  # pylint: disable=too-many-instance-attributes
         _device_id = reduce(lambda x, y: x * 0x100 + y, id_data)
         return _device_id
 
+    def get_gd_id(self):
+        """Send the 'Get GD ID' command and return the chip/product/device ID."""
+        self.command(self.Command.GET_GD_ID, "Get GD ID")
+        length = bytearray(self.connection.read())[0]
+        # GD32 0x06 command returns N+1 bytes where N is the count,
+        # but the last byte is ACK, not part of data
+        id_data = bytearray(self.connection.read(length))
+        self._wait_for_ack("0x06 end")
+        # Convert 4-byte part number to pid (little-endian 32-bit integer)
+        # For GD32 devices, the part number is returned as ASCII characters
+        # Example: "7HMP" -> 0x37 0x48 0x4D 0x50 -> 0x504D4837
+        _part_number_to_pid = lambda data: (
+            (data[3] << 24) | (data[2] << 16) | (data[1] << 8) | data[0]
+            if len(data) >= 4 else 0
+        )
+        _device_id = _part_number_to_pid(id_data)
+        return _device_id
+
     def get_flash_size(self):
         """Return the MCU's flash size in kilobytes."""
         if self.device.flags & DeviceFlag.LONG_UID_ACCESS:
@@ -611,7 +648,11 @@ class Stm32Bootloader:  # pylint: disable=too-many-instance-attributes
 
     def detect_device(self) -> None:
         """Detect the device type and store in `device`."""
-        product_id = self.get_id()
+        product_id = None
+        try:
+            product_id = self.get_id()
+        except CommandError:
+            product_id = self.get_gd_id()
 
         # Look up device details based on ID *without* bootloader ID.
         self.device = DEVICES.get((product_id, None))

--- a/src/stm32loader/device_family.py
+++ b/src/stm32loader/device_family.py
@@ -36,6 +36,7 @@ class DeviceFamily(enum.Enum):
 
     # Non-STM devices.
     WIZ = "WIZ"
+    GD32VW55x = "GD32VW55x"
 
 
 @enum.unique
@@ -210,6 +211,13 @@ DEVICE_FAMILIES = {
     ),
     DeviceFamily.WIZ: DeviceFamilyInfo(
         "WIZ",
+    ),
+    # GigaDevice GD32VW55x series.
+    # Uses 0x06 command to get part number instead of standard 0x02.
+    DeviceFamily.GD32VW55x: DeviceFamilyInfo(
+        "GD32VW55x",
+        flash_page_size=4096,
+        transfer_size=240,
     ),
 }
 

--- a/src/stm32loader/devices.py
+++ b/src/stm32loader/devices.py
@@ -1080,6 +1080,97 @@ DEVICE_DETAILS = [
     ),
     # Wiznet W7500
     DeviceInfo("WIZ", "Wiznet W7500", 0x801, bid=None, ram=None, system=None),
+    # GigaDevice GD32VW553 series
+    # Uses 0x06 command to get part number (pid is 4-byte ASCII in little-endian)
+    # Find these pid in GD32_ISP_CLI(Linux)->libGD_MCU_DLL.so->BuildMap_GD32103
+    # pid "6KIP" = 0x36 0x4B 0x49 0x50 -> 0x50494B36
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553KIQ6",
+        pid=0x50494B36,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08200000, 4 * kB),  # 2MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
+    # pid "6KMP" = 0x36 0x4B 0x4D 0x50 -> 0x504D4B36
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553KMQ6",
+        pid=0x504D4B36,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08400000, 4 * kB),  # 4MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
+    # pid "6HIP" = 0x36 0x48 0x49 0x50 -> 0x50494836
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553HIQ6",
+        pid=0x50494836,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08200000, 4 * kB),  # 2MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
+    # pid "6HMP" = 0x36 0x48 0x4D 0x50 -> 0x504D4836
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553HMQ6",
+        pid=0x504D4836,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08400000, 4 * kB),  # 4MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
+    # pid "7KIP" = 0x37 0x4B 0x49 0x50 -> 0x50494B37
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553KIQ7",
+        pid=0x50494B37,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08200000, 4 * kB),  # 2MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
+    # pid "7KMP" = 0x37 0x4B 0x4D 0x50 -> 0x504D4B37
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553KMQ7",
+        pid=0x504D4B37,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08400000, 4 * kB),  # 4MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
+    # pid "7HIP" = 0x37 0x48 0x49 0x50 -> 0x50494837
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553HIQ7",
+        pid=0x50494837,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08200000, 4 * kB),  # 2MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
+    # pid "7HMP" = 0x37 0x48 0x4D 0x50 -> 0x504D4837
+    DeviceInfo(
+        "GD32VW55x",
+        "GD32VW553HMQ7",
+        pid=0x504D4837,
+        bid=None,
+        ram=(0x20000000, 0x20050000),  # 320KB
+        system=(0x0BF40000, 0x0BF80000),
+        flash=(0x08000000, 0x08400000, 4 * kB),  # 4MB, 4KB pages
+        option=(0x0FFC0000, 0x0FFC0100),
+    ),
 ]
 
 DEVICES = {(dev.product_id, dev.bootloader_id): dev for dev in DEVICE_DETAILS}


### PR DESCRIPTION
test:
```shell
$ uv run python -m stm32loader -V --port /dev/cu.wchusbserial840                                                    
Open port /dev/cu.wchusbserial840, baud 115200
Data transfer size updated: 128 bytes
Flash page size updated: 1024 bytes
Activating bootloader (select UART)
*** Command: Get
    Bootloader version: 0x30
    Available commands: 0x0, 0x11, 0x21, 0x31, 0x44, 0x63, 0x73, 0x82, 0x92
Bootloader version: 0x30
*** Command: Get ID
*** Command: Get GD ID
Data transfer size updated: 240 bytes
Flash page size updated: 4096 bytes
Chip ID: 0x504D4837
Chip model: GD32VW553HMQ7
Flash size: 4096 kiB

$ uv run python -m stm32loader --port /dev/cu.wchusbserial840 -b 1000000 -e -w ../stm32loader/ble_app_uart_blink.bin
Activating bootloader (select UART)
Bootloader version: 0x30
Chip ID: 0x504D4837
Chip model: GD32VW553HMQ7
Flash size: 4096 kiB
Performing full erase...
Flash global erase
Extended erase (0x44), this can take ten seconds or more
Write 307064 bytes in 1280 chunks at address 0x8000000...
Writing ████████████████████████████████ 1280/1280
```